### PR TITLE
Darth ksane locale fix

### DIFF
--- a/i18n/deDE.lua
+++ b/i18n/deDE.lua
@@ -3,7 +3,7 @@ local addonName, addon = ...
 local locale = GetLocale()
 
 if locale == "deDE" then
-    local L = {}
+    local L = addon.L
     L["ShowHKs"] = "Zeige Ehrenhafte Siege";
     L["ShowHKsDescription"] = "Shows the total number of honor kills within the data text."
 

--- a/i18n/esES.lua
+++ b/i18n/esES.lua
@@ -3,7 +3,7 @@ local addonName, addon = ...
 local locale = GetLocale()
 
 if locale == "esES" then
-    local L = {}
+    local L = addon.L
     L["ShowHKs"] = "Show Honor Kills";
     L["ShowHKsDescription"] = "Shows the total number of honor kills within the data text."
 

--- a/i18n/frFR.lua
+++ b/i18n/frFR.lua
@@ -3,7 +3,7 @@ local addonName, addon = ...
 local locale = GetLocale()
 
 if locale == "frFR" then
-    local L = {}
+    local L = addon.L
     L["ShowHKs"] = "Afficher Victoires Honorables";
     L["ShowHKsDescription"] = "Shows the total number of honor kills within the data text."
 

--- a/i18n/ruRU.lua
+++ b/i18n/ruRU.lua
@@ -3,7 +3,7 @@ local addonName, addon = ...
 local locale = GetLocale()
 
 if locale == "ruRU" then
-    local L = {}
+    local L = addon.L
 -- Configuration options
 	L["showHKs"] = "Почётные победы";
 	L["showHKsDescription"] = "Показывать общее количество почётных побед.";


### PR DESCRIPTION
Problem: if any of localized strings is absent - addon can't show Settings dialog.
Changed L={} to L=addon.L, so that missing localized strings would be in English and addon would be able to show Settings dialog.